### PR TITLE
Add more tests to replace, substring, and extract

### DIFF
--- a/pyteal/ast/replace.py
+++ b/pyteal/ast/replace.py
@@ -26,7 +26,7 @@ class ReplaceExpr(Expr):
         self.replacement = replacement
 
     # helper method for correctly populating op
-    def __getOp(self, options: "CompileOptions"):
+    def __get_op(self, options: "CompileOptions"):
         s = cast(Int, self.start).value
         if s < 2**8:
             return Op.replace2
@@ -44,7 +44,7 @@ class ReplaceExpr(Expr):
                 self.replacement,
             ).__teal__(options)
 
-        op = self.__getOp(options)
+        op = self.__get_op(options)
 
         verifyTealVersion(
             op.min_version,

--- a/pyteal/ast/replace_test.py
+++ b/pyteal/ast/replace_test.py
@@ -29,7 +29,7 @@ def test_replace_immediate():
         expr.__teal__(teal6Options)
 
 
-def test_replace_stack():
+def test_replace_stack_int():
     my_string = "*" * 257
     args = [pt.Bytes(my_string), pt.Int(256), pt.Bytes("ab")]
     expr = pt.Replace(args[0], args[1], args[2])
@@ -49,6 +49,36 @@ def test_replace_stack():
     actual = pt.TealBlock.NormalizeBlocks(actual)
 
     assert actual == expected
+
+    with pytest.raises(pt.TealInputError):
+        expr.__teal__(teal6Options)
+
+
+# Mirrors `test_replace_stack_int`, but attempts replacement with start != pt.Int.
+def test_replace_stack_not_int():
+    my_string = "*" * 257
+    add = pt.Add(pt.Int(254), pt.Int(2))
+    args = [pt.Bytes(my_string), add, pt.Bytes("ab")]
+    expr = pt.Replace(args[0], args[1], args[2])
+    assert expr.type_of() == pt.TealType.bytes
+
+    expected = pt.TealSimpleBlock(
+        [
+            pt.TealOp(args[0], pt.Op.byte, '"{my_string}"'.format(my_string=my_string)),
+            pt.TealOp(pt.Int(254), pt.Op.int, 254),
+            pt.TealOp(pt.Int(2), pt.Op.int, 2),
+            pt.TealOp(add, pt.Op.add),
+            pt.TealOp(args[2], pt.Op.byte, '"ab"'),
+            pt.TealOp(expr, pt.Op.replace3),
+        ]
+    )
+
+    actual, _ = expr.__teal__(teal7Options)
+    actual.addIncoming()
+    actual = pt.TealBlock.NormalizeBlocks(actual)
+
+    with pt.TealComponent.Context.ignoreExprEquality():
+        assert actual == expected
 
     with pytest.raises(pt.TealInputError):
         expr.__teal__(teal6Options)

--- a/pyteal/ast/substring.py
+++ b/pyteal/ast/substring.py
@@ -26,7 +26,7 @@ class SubstringExpr(Expr):
         self.endArg = endArg
 
     # helper method for correctly populating op
-    def __getOp(self, options: "CompileOptions"):
+    def __get_op(self, options: "CompileOptions"):
         s, e = cast(Int, self.startArg).value, cast(Int, self.endArg).value
         l = e - s
 
@@ -58,7 +58,7 @@ class SubstringExpr(Expr):
                 self.endArg,
             ).__teal__(options)
 
-        op = self.__getOp(options)
+        op = self.__get_op(options)
 
         verifyTealVersion(
             op.min_version,
@@ -121,7 +121,7 @@ class ExtractExpr(Expr):
         self.lenArg = lenArg
 
     # helper method for correctly populating op
-    def __getOp(self, options: "CompileOptions"):
+    def __get_op(self, options: "CompileOptions"):
         s, l = cast(Int, self.startArg).value, cast(Int, self.lenArg).value
         if s < 2**8 and l > 0 and l < 2**8:
             return Op.extract
@@ -139,7 +139,7 @@ class ExtractExpr(Expr):
                 self.lenArg,
             ).__teal__(options)
 
-        op = self.__getOp(options)
+        op = self.__get_op(options)
 
         verifyTealVersion(
             op.min_version,
@@ -186,7 +186,7 @@ class SuffixExpr(Expr):
         self.startArg = startArg
 
     # helper method for correctly populating op
-    def __getOp(self, options: "CompileOptions"):
+    def __get_op(self, options: "CompileOptions"):
         if not isinstance(self.startArg, Int):
             return Op.substring3
 
@@ -197,7 +197,7 @@ class SuffixExpr(Expr):
             return Op.substring3
 
     def __teal__(self, options: "CompileOptions"):
-        op = self.__getOp(options)
+        op = self.__get_op(options)
 
         verifyTealVersion(
             op.min_version,


### PR DESCRIPTION
Extends https://github.com/algorand/pyteal/pull/413 with tests covering `TernaryExpr` use cases for `substring3`, `extract3, and `replace3`.

I originally started writing tests because I thought the TEAL minimum version invariant was _not_ checked.  Although the invariant is checked, I opted to finish adding tests to increase test coverage.

Details:
* Renames `__getOp` to `__get_op` in order to follow PEP 8 naming conventions.  It's _safe_ to change existing references because the method is (marked) private. 
* Extends `pyteal/ast/substring_test.py` because it looks like https://github.com/algorand/pyteal/pull/413 mirrored the approach taken in `substring`.